### PR TITLE
feat: Add support for S3 storage key prefixes

### DIFF
--- a/charts/ort-server/templates/_env.tpl
+++ b/charts/ort-server/templates/_env.tpl
@@ -120,6 +120,10 @@ properties have environment variable substitutions configured.
 {{- end }}
 - name: FILE_ARCHIVE_STORAGE_BUCKET_NAME
   value: {{ .Values.storage.s3.buckets.fileArchives | quote }}
+{{- if .Values.storage.s3.prefixes.fileArchives }}
+- name: FILE_ARCHIVE_STORAGE_KEY_PREFIX
+  value: {{ .Values.storage.s3.prefixes.fileArchives | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -160,6 +164,10 @@ properties have environment variable substitutions configured.
 {{- end }}
 - name: FILE_LIST_STORAGE_BUCKET_NAME
   value: {{ .Values.storage.s3.buckets.fileLists | quote }}
+{{- if .Values.storage.s3.prefixes.fileLists }}
+- name: FILE_LIST_STORAGE_KEY_PREFIX
+  value: {{ .Values.storage.s3.prefixes.fileLists | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -200,5 +208,9 @@ properties have environment variable substitutions configured.
 {{- end }}
 - name: REPORT_STORAGE_BUCKET_NAME
   value: {{ .Values.storage.s3.buckets.reports | quote }}
+{{- if .Values.storage.s3.prefixes.reports }}
+- name: REPORT_STORAGE_KEY_PREFIX
+  value: {{ .Values.storage.s3.prefixes.reports | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/ort-server/values.yaml
+++ b/charts/ort-server/values.yaml
@@ -125,6 +125,16 @@ storage:
       fileLists: file-lists
       ## @param storage.s3.buckets.reports The name of the S3 bucket to use for storing reports.
       reports: reports
+    prefixes:
+      ## @param storage.s3.prefixes.fileArchives An optional prefix to use for storing file archives in the S3 bucket.
+      ## Required when sharing the bucket with file lists or reports to avoid name collisions.
+      fileArchives: ""
+      ## @param storage.s3.prefixes.fileLists An optional prefix to use for storing file lists in the S3 bucket.
+      ## Required when sharing the bucket with file archives or reports to avoid name collisions.
+      fileLists: ""
+      ## @param storage.s3.prefixes.reports An optional prefix to use for storing reports in the S3 bucket.
+      ## Required when sharing the bucket with file archives or file lists to avoid name collisions.
+      reports: ""
 
 transport:
   queues:


### PR DESCRIPTION
The prefixes are required when using the same S3 bucket for different types of artifacts.