### PR TITLE
ci(renovate): Use the config preset from the renovate repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver",
-    ":semanticCommitScopeDisabled",
-    ":semanticCommitTypeAll(deps)"
+    "github>eclipse-apoapsis/renovate"
   ],
-  "dependencyDashboard": false,
-  "labels": ["dependencies"],
-  "prHourlyLimit": 5,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Also remove config options which are now inherited from the preset. See [1] for an explanation of the syntax.

[1]: https://docs.renovatebot.com/config-presets/#github