### PR TITLE
ci(release-please): Fix replacing version in README

### DIFF
--- a/charts/ort-server/README.md
+++ b/charts/ort-server/README.md
@@ -1,6 +1,8 @@
 # ort-server
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) <!-- x-release-please-version -->
+<!-- x-release-please-start-version -->
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square)
+<!-- x-release-please-end -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 0.61.0](https://img.shields.io/badge/AppVersion-0.61.0-informational?style=flat-square)
 

--- a/charts/ort-server/README.md.gotmpl
+++ b/charts/ort-server/README.md.gotmpl
@@ -1,7 +1,9 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-![Version: {{ template "chart.version" . }}](https://img.shields.io/badge/Version-{{ template "chart.version" . }}-informational?style=flat-square) <!-- x-release-please-version -->
+<!-- x-release-please-start-version -->
+![Version: {{ template "chart.version" . }}](https://img.shields.io/badge/Version-{{ template "chart.version" . }}-informational?style=flat-square)
+<!-- x-release-please-end -->
 {{ template "chart.typeBadge" . }}
 {{ template "chart.appVersionBadge" . }}
 


### PR DESCRIPTION
With the `x-release-please-version` annotation only the first occurence of the version gets replaced. Switch to the block annotations as this should replace multiple versions [1].

[1]: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files