### PR TITLE
ci(release-please): Try another fix for updating the version in README

### DIFF
--- a/charts/ort-server/README.md
+++ b/charts/ort-server/README.md
@@ -1,7 +1,7 @@
 # ort-server
 
 <!-- x-release-please-start-version -->
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square)
+![Version: 0.15.0][version-badge]
 <!-- x-release-please-end -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 0.61.0](https://img.shields.io/badge/AppVersion-0.61.0-informational?style=flat-square)
@@ -196,3 +196,7 @@ A generic Helm chart for the ORT Server.
 | ui.extraVolumes | list | `[]` | Additional volumes for the UI deployment |
 | ui.extraVolumeMounts | list | `[]` | Additional volume mounts for the UI deployment |
 | extraObjects | list | `[]` |  |
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square
+<!-- x-release-please-end -->

--- a/charts/ort-server/README.md.gotmpl
+++ b/charts/ort-server/README.md.gotmpl
@@ -2,7 +2,7 @@
 {{ template "chart.deprecationWarning" . }}
 
 <!-- x-release-please-start-version -->
-![Version: {{ template "chart.version" . }}](https://img.shields.io/badge/Version-{{ template "chart.version" . }}-informational?style=flat-square)
+![Version: {{ template "chart.version" . }}][version-badge]
 <!-- x-release-please-end -->
 {{ template "chart.typeBadge" . }}
 {{ template "chart.appVersionBadge" . }}
@@ -18,3 +18,7 @@
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+<!-- x-release-please-start-version -->
+[version-badge]: https://img.shields.io/badge/Version-{{ template "chart.version" . }}-informational?style=flat-square
+<!-- x-release-please-end -->


### PR DESCRIPTION
The fix in 9b87fe7 did not work as release-please still only updates one occurrence of the version within a block. Try if separating the badge into two blocks fixes the issue.