### PR TITLE
fix(release-please): URL encode the dash after the version

### DIFF
--- a/charts/ort-server/README.md
+++ b/charts/ort-server/README.md
@@ -1,8 +1,6 @@
 # ort-server
 
-<!-- x-release-please-start-version -->
-![Version: 0.15.0][version-badge]
-<!-- x-release-please-end -->
+![Version: 0.15.0][version-badge] <!-- x-release-please-version -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 0.61.0](https://img.shields.io/badge/AppVersion-0.61.0-informational?style=flat-square)
 

--- a/charts/ort-server/README.md
+++ b/charts/ort-server/README.md
@@ -198,5 +198,5 @@ A generic Helm chart for the ORT Server.
 | extraObjects | list | `[]` |  |
 
 <!-- x-release-please-start-version -->
-[version-badge]: https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square
+[version-badge]: https://img.shields.io/badge/Version-0.15.0%2Dinformational?style=flat-square
 <!-- x-release-please-end -->

--- a/charts/ort-server/README.md.gotmpl
+++ b/charts/ort-server/README.md.gotmpl
@@ -20,5 +20,5 @@
 {{ template "chart.valuesSection" . }}
 
 <!-- x-release-please-start-version -->
-[version-badge]: https://img.shields.io/badge/Version-{{ template "chart.version" . }}-informational?style=flat-square
+[version-badge]: https://img.shields.io/badge/Version-{{ template "chart.version" . }}%2Dinformational?style=flat-square
 <!-- x-release-please-end -->

--- a/charts/ort-server/README.md.gotmpl
+++ b/charts/ort-server/README.md.gotmpl
@@ -1,9 +1,7 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-<!-- x-release-please-start-version -->
-![Version: {{ template "chart.version" . }}][version-badge]
-<!-- x-release-please-end -->
+![Version: {{ template "chart.version" . }}][version-badge] <!-- x-release-please-version -->
 {{ template "chart.typeBadge" . }}
 {{ template "chart.appVersionBadge" . }}
 


### PR DESCRIPTION
This avoids that the regex release-please uses to match the version includes the color value of the shields.io URL.