### PR TITLE
ci(renovate): Update app version badge in README.md

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,16 @@
       "matchStrings": ["appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"],
       "depNameTemplate": "eclipse-apoapsis/ort-server",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^charts/ort-server/README\\.md$"],
+      "matchStrings": [
+        "!\\[AppVersion: (?<currentValue>[^\\]]+)\\]",
+        "badge/AppVersion-(?<currentValue>[^-]+)-informational"
+      ],
+      "depNameTemplate": "eclipse-apoapsis/ort-server",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
The README.md contains an AppVersion shields.io badge that displays the current app version. Previously, Renovate only updated the appVersion in Chart.yaml, leaving the README badge out of sync.

Add a second custom regex manager to target README.md separately, with two match strings: one for the badge alt text and one for the shields.io URL. Both occurrences are updated in the same PR as the Chart.yaml change, since Renovate groups updates for the same dependency and datasource into a single branch.