### PR TITLE
fix: Add missing permissions to tasks service account

### DIFF
--- a/charts/ort-server/templates/tasks/role.yaml
+++ b/charts/ort-server/templates/tasks/role.yaml
@@ -7,6 +7,14 @@ metadata:
     {{- include "ortserver.labels" . | nindent 4 }}
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+  - apiGroups:
       - batch
     resources:
       - jobs


### PR DESCRIPTION
The permissions are required by the reaper task to clean up old pods.