### PR TITLE
docs: Update the command to install the dev-stack chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ kubectl wait --for=condition=established crd/logstashes.logstash.k8s.elastic.co 
 
 ```shell
 helm dependency update charts/dev-stack
-helm install dev charts/dev-stack --timeout 20m
+helm upgrade --install dev charts/dev-stack --timeout 20m --force-conflicts
 ```
 
 ## Contributing


### PR DESCRIPTION
Use a command that can be used for the initial install and for upgrades. The `--force-conflicts` option is required because the ECK operator might take ownership of `.spec.nodeSets` which Helm also needs to set when installing the chart.