### PR TITLE
 Add support for existing Kubernetes secrets

### DIFF
--- a/charts/ort-server/Chart.yaml
+++ b/charts/ort-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ort-server
 description: A generic Helm chart for the ORT Server.
 type: application
-version: 0.21.2
+version: 0.21.3
 appVersion: "0.82.1"

--- a/charts/ort-server/README.md
+++ b/charts/ort-server/README.md
@@ -1,6 +1,6 @@
 # ort-server
 
-![Version: 0.21.2][version-badge] <!-- x-release-please-version -->
+![Version: 0.21.3][version-badge] <!-- x-release-please-version -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 0.82.1](https://img.shields.io/badge/AppVersion-0.82.1-informational?style=flat-square)
 
@@ -41,7 +41,9 @@ A generic Helm chart for the ORT Server.
 | database.name | string | `"ort-server"` | The name of the database to connect to. |
 | database.schema | string | `"ort-server"` | The database schema to use. |
 | database.username | string | `"ort-server"` | The username to use for connecting to the database. |
-| database.password | string | `"ort-server"` | The password to use for connecting to the database. |
+| database.password | string | `"ort-server"` | The password to use for connecting to the database. Ignored if `existingSecret` is set. |
+| database.existingSecret | string | `""` | Name of an existing secret to use for the database password, instead of setting it in plain text via `password`. |
+| database.secretKeys.passwordKey | string | `"database-password"` | Name of the key in the existing secret that contains the database password. |
 | database.connectionTimeout | string | `""` | Optional maximum time in milliseconds to wait for a connection from the pool. If not set, the server default is used. |
 | database.idleTimeout | string | `""` | Optional maximum time in milliseconds that a connection is allowed to sit idle in the pool. If not set, the server default is used. |
 | database.keepaliveTime | string | `""` | Optional interval in milliseconds in which connections are tested for aliveness. If not set, the server default is used. |
@@ -56,8 +58,11 @@ A generic Helm chart for the ORT Server.
 | secrets.azureKeyVault.enabled | bool | `false` | If enabled, user secrets are stored in Azure Key Vault. |
 | secrets.azureKeyVault.keyVaultName | string | `""` | The name of the Azure Key Vault to use. |
 | secrets.database.enabled | bool | `false` | If enabled, database credentials are stored in the database. |
-| secrets.database.masterPassword | string | `""` | Master password for encrypting secrets stored in the database. Must be at least 16 characters long. |
-| secrets.database.salt | string | `""` | Salt for encrypting secrets stored in the database. Must be a hex-encoded string of at least 32 hex characters. |
+| secrets.database.masterPassword | string | `""` | Master password for encrypting secrets stored in the database. Must be at least 16 characters long. Ignored if `existingSecret` is set. |
+| secrets.database.salt | string | `""` | Salt for encrypting secrets stored in the database. Must be a hex-encoded string of at least 32 hex characters. Ignored if `existingSecret` is set. |
+| secrets.database.existingSecret | string | `""` | Name of an existing secret to use for the master password and salt, instead of setting them in plain text via `masterPassword`/`salt`. |
+| secrets.database.secretKeys.masterPasswordKey | string | `"master-password"` | Name of the key in the existing secret that contains the master password. |
+| secrets.database.secretKeys.saltKey | string | `"salt"` | Name of the key in the existing secret that contains the salt. |
 | secrets.database.keyVersion | int | `1` | Version of the encryption key. Do not change, key rotation is not yet supported. |
 | secrets.fileBased.enabled | bool | `true` | If enabled, user secrets are stored in a file. This should only be used for testing, not in production. |
 | secrets.fileBased.path | string | `"/mnt/secrets/secrets"` | Path to the file where user secrets are stored. |
@@ -150,7 +155,9 @@ A generic Helm chart for the ORT Server.
 | transport.rabbitmq.enabled | bool | `true` | If enabled, RabbitMQ is used as the message broker. |
 | transport.rabbitmq.serverUri | string | `""` | The URI of the RabbitMQ server to connect to when using RabbitMQ as the message broker. Must be in the format amqp://username:password@host:port/vhost. |
 | transport.rabbitmq.username | string | `""` | The username to use for connecting to the RabbitMQ server. |
-| transport.rabbitmq.password | string | `""` | The password to use for connecting to the RabbitMQ server. |
+| transport.rabbitmq.password | string | `""` | The password to use for connecting to the RabbitMQ server. Ignored if `existingSecret` is set. |
+| transport.rabbitmq.existingSecret | string | `""` | Name of an existing secret to use for the RabbitMQ password, instead of setting it in plain text via `password`. |
+| transport.rabbitmq.secretKeys.passwordKey | string | `"rabbitmq-password"` | Name of the key in the existing secret that contains the RabbitMQ password. |
 | core.strategy | object | `{"type":"RollingUpdate"}` | Deployment strategy for the core component |
 | core.uiHosts | string | `"localhost:5173,localhost:8082"` | Comma-separated list of hosts that are allowed for cross-origin request sharing (CORS) when accessing the API. This should usually include the host of the UI deployment. |
 | core.service.port | int | `8081` | The port to use for the core service (API). |
@@ -161,7 +168,9 @@ A generic Helm chart for the ORT Server.
 | core.keycloak.accessTokenUrl | string | `"https://keycloak.ortserver.org/realms/master/protocol/openid-connect/token"` | The URL of the Keycloak server's token endpoint for obtaining access tokens to call the Keycloak API. |
 | core.keycloak.apiUrl | string | `"https://keycloak.ortserver.org/admin/realms/master"` | The URL of the Keycloak server's admin API endpoint. |
 | core.keycloak.apiUser | string | `"ort-server"` | The username to use for authenticating to the Keycloak admin API. Set to an empty string when using the client credentials flow. |
-| core.keycloak.apiSecret | string | `"ort-server"` | The password to use for authenticating to the Keycloak admin API. |
+| core.keycloak.apiSecret | string | `"ort-server"` | The password to use for authenticating to the Keycloak admin API. Ignored if `existingSecret` is set. |
+| core.keycloak.existingSecret | string | `""` | Name of an existing secret to use for the Keycloak admin API password, instead of setting it in plain text via `apiSecret`. |
+| core.keycloak.secretKeys.apiSecretKey | string | `"keycloak-api-secret"` | Name of the key in the existing secret that contains the Keycloak admin API password. |
 | core.keycloak.clientId | string | `"admin-cli"` | The client ID to use for authenticating to the Keycloak admin API. |
 | core.livenessProbe.enabled | bool | `true` | Enable livenessProbe for the core deployment |
 | core.livenessProbe.initialDelaySeconds | int | `60` | Initial delay before the liveness probe is initiated |
@@ -258,5 +267,5 @@ A generic Helm chart for the ORT Server.
 | extraObjects | list | `[]` |  |
 
 <!-- x-release-please-start-version -->
-[version-badge]: https://img.shields.io/badge/Version-0.21.2%2Dinformational?style=flat-square
+[version-badge]: https://img.shields.io/badge/Version-0.21.3%2Dinformational?style=flat-square
 <!-- x-release-please-end -->

--- a/charts/ort-server/templates/_env.tpl
+++ b/charts/ort-server/templates/_env.tpl
@@ -11,7 +11,14 @@
 - name: DB_USERNAME
   value: {{ .Values.database.username | quote }}
 - name: DB_PASSWORD
+{{- if .Values.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.existingSecret }}
+      key: {{ .Values.database.secretKeys.passwordKey }}
+{{- else }}
   value: {{ .Values.database.password | quote }}
+{{- end }}
 {{- with .Values.database.connectionTimeout }}
 - name: DB_CONNECTION_TIMEOUT
   value: {{ . | quote }}
@@ -56,6 +63,23 @@
 {{- end }}
 {{- end -}}
 
+{{/*
+Environment variable entry for a RabbitMQ password (used for CONFIG_FORCE_* overrides). Expects a dict with:
+  - root: the root template context (.)
+  - envName: the name of the environment variable to set
+*/}}
+{{- define "ortserver.env.rabbitmqPassword" -}}
+- name: {{ .envName }}
+{{- if .root.Values.transport.rabbitmq.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .root.Values.transport.rabbitmq.existingSecret }}
+      key: {{ .root.Values.transport.rabbitmq.secretKeys.passwordKey }}
+{{- else }}
+  value: {{ .root.Values.transport.rabbitmq.password | quote }}
+{{- end }}
+{{- end -}}
+
 {{/* Environment variables to configure the provider for admin secrets. */}}
 {{- define "ortserver.env.adminSecrets" -}}
 - name: ALLOW_SECRETS_FROM_CONFIG
@@ -73,9 +97,23 @@
 - name: SECRETS_PROVIDER_NAME
   value: database
 - name: DATABASE_SECRETS_MASTER_PASSWORD
+{{- if .Values.secrets.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.database.existingSecret }}
+      key: {{ .Values.secrets.database.secretKeys.masterPasswordKey }}
+{{- else }}
   value: {{ .Values.secrets.database.masterPassword | quote }}
+{{- end }}
 - name: DATABASE_SECRETS_SALT
+{{- if .Values.secrets.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.database.existingSecret }}
+      key: {{ .Values.secrets.database.secretKeys.saltKey }}
+{{- else }}
   value: {{ .Values.secrets.database.salt | quote }}
+{{- end }}
 - name: DATABASE_SECRETS_KEY_VERSION
   value: "{{ .Values.secrets.database.keyVersion }}"
 {{- else if .Values.secrets.fileBased.enabled }}

--- a/charts/ort-server/templates/core/deployment.yaml
+++ b/charts/ort-server/templates/core/deployment.yaml
@@ -116,7 +116,14 @@ spec:
             - name: KEYCLOAK_API_USER
               value: {{ .Values.core.keycloak.apiUser }}
             - name: KEYCLOAK_API_SECRET
+            {{- if .Values.core.keycloak.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.core.keycloak.existingSecret }}
+                  key: {{ .Values.core.keycloak.secretKeys.apiSecretKey }}
+            {{- else }}
               value: {{ .Values.core.keycloak.apiSecret }}
+            {{- end }}
             - name: KEYCLOAK_CLIENT_ID
               value: {{ .Values.core.keycloak.clientId }}
 
@@ -131,8 +138,7 @@ spec:
             # The RabbitMQ transport does not use the default properties for the credentials.
             - name: CONFIG_FORCE_orchestrator_sender_rabbitMqUser
               value: {{ .Values.transport.rabbitmq.username }}
-            - name: CONFIG_FORCE_orchestrator_sender_rabbitMqPassword
-              value: {{ .Values.transport.rabbitmq.password }}
+            {{- include "ortserver.env.rabbitmqPassword" (dict "root" $ "envName" "CONFIG_FORCE_orchestrator_sender_rabbitMqPassword") | nindent 12 }}
             # - name: ORCHESTRATOR_SENDER_TRANSPORT_USERNAME
             #   value: {{ .Values.transport.rabbitmq.username }}
             # - name: ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD

--- a/charts/ort-server/templates/orchestrator/deployment.yaml
+++ b/charts/ort-server/templates/orchestrator/deployment.yaml
@@ -97,8 +97,7 @@ spec:
             # The RabbitMQ transport does not use the default properties for the credentials.
             - name: CONFIG_FORCE_orchestrator_receiver_rabbitMqUser
               value: {{ .Values.transport.rabbitmq.username }}
-            - name: CONFIG_FORCE_orchestrator_receiver_rabbitMqPassword
-              value: {{ .Values.transport.rabbitmq.password }}
+            {{- include "ortserver.env.rabbitmqPassword" (dict "root" $ "envName" "CONFIG_FORCE_orchestrator_receiver_rabbitMqPassword") | nindent 12 }}
             # - name: ORCHESTRATOR_RECEIVER_TRANSPORT_USERNAME
             #   value: {{ .Values.transport.rabbitmq.username }}
             # - name: ORCHESTRATOR_RECEIVER_TRANSPORT_PASSWORD
@@ -116,8 +115,7 @@ spec:
             # The RabbitMQ transport does not use the default properties for the credentials.
             - name: CONFIG_FORCE_orchestrator_sender_rabbitMqUser
               value: {{ .Values.transport.rabbitmq.username }}
-            - name: CONFIG_FORCE_orchestrator_sender_rabbitMqPassword
-              value: {{ .Values.transport.rabbitmq.password }}
+            {{- include "ortserver.env.rabbitmqPassword" (dict "root" $ "envName" "CONFIG_FORCE_orchestrator_sender_rabbitMqPassword") | nindent 12 }}
             # - name: ORCHESTRATOR_SENDER_TRANSPORT_USERNAME
             #   value: {{ .Values.transport.rabbitmq.username }}
             # - name: ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD

--- a/charts/ort-server/templates/tasks/cronjob.yaml
+++ b/charts/ort-server/templates/tasks/cronjob.yaml
@@ -72,8 +72,7 @@ spec:
                 # The RabbitMQ transport does not use the default properties for the credentials.
                 - name: CONFIG_FORCE_orchestrator_sender_rabbitMqUser
                   value: {{ $.Values.transport.rabbitmq.username }}
-                - name: CONFIG_FORCE_orchestrator_sender_rabbitMqPassword
-                  value: {{ $.Values.transport.rabbitmq.password }}
+                {{- include "ortserver.env.rabbitmqPassword" (dict "root" $ "envName" "CONFIG_FORCE_orchestrator_sender_rabbitMqPassword") | nindent 16 }}
                 # - name: ORCHESTRATOR_SENDER_TRANSPORT_USERNAME
                 #   value: {{ $.Values.transport.rabbitmq.username }}
                 # - name: ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD

--- a/charts/ort-server/values.yaml
+++ b/charts/ort-server/values.yaml
@@ -75,8 +75,13 @@ database:
   schema: ort-server
   # -- The username to use for connecting to the database.
   username: ort-server
-  # -- The password to use for connecting to the database.
+  # -- The password to use for connecting to the database. Ignored if `existingSecret` is set.
   password: ort-server
+  # -- Name of an existing secret to use for the database password, instead of setting it in plain text via `password`.
+  existingSecret: ""
+  secretKeys:
+    # -- Name of the key in the existing secret that contains the database password.
+    passwordKey: "database-password"
   # -- Optional maximum time in milliseconds to wait for a connection from the pool. If not set, the server default is used.
   connectionTimeout: ""
   # -- Optional maximum time in milliseconds that a connection is allowed to sit idle in the pool. If not set, the server default is used.
@@ -109,10 +114,17 @@ secrets:
   database:
     # -- If enabled, database credentials are stored in the database.
     enabled: false
-    # -- Master password for encrypting secrets stored in the database. Must be at least 16 characters long.
+    # -- Master password for encrypting secrets stored in the database. Must be at least 16 characters long. Ignored if `existingSecret` is set.
     masterPassword: ""
-    # -- Salt for encrypting secrets stored in the database. Must be a hex-encoded string of at least 32 hex characters.
+    # -- Salt for encrypting secrets stored in the database. Must be a hex-encoded string of at least 32 hex characters. Ignored if `existingSecret` is set.
     salt: ""
+    # -- Name of an existing secret to use for the master password and salt, instead of setting them in plain text via `masterPassword`/`salt`.
+    existingSecret: ""
+    secretKeys:
+      # -- Name of the key in the existing secret that contains the master password.
+      masterPasswordKey: "master-password"
+      # -- Name of the key in the existing secret that contains the salt.
+      saltKey: "salt"
     # -- Version of the encryption key. Do not change, key rotation is not yet supported.
     keyVersion: 1
   fileBased:
@@ -362,8 +374,13 @@ transport:
     serverUri: ""
     # -- The username to use for connecting to the RabbitMQ server.
     username: ""
-    # -- The password to use for connecting to the RabbitMQ server.
+    # -- The password to use for connecting to the RabbitMQ server. Ignored if `existingSecret` is set.
     password: ""
+    # -- Name of an existing secret to use for the RabbitMQ password, instead of setting it in plain text via `password`.
+    existingSecret: ""
+    secretKeys:
+      # -- Name of the key in the existing secret that contains the RabbitMQ password.
+      passwordKey: "rabbitmq-password"
 
 core:
   # -- Deployment strategy for the core component
@@ -390,8 +407,13 @@ core:
     apiUrl: https://keycloak.ortserver.org/admin/realms/master
     # -- The username to use for authenticating to the Keycloak admin API. Set to an empty string when using the client credentials flow.
     apiUser: ort-server
-    # -- The password to use for authenticating to the Keycloak admin API.
+    # -- The password to use for authenticating to the Keycloak admin API. Ignored if `existingSecret` is set.
     apiSecret: ort-server
+    # -- Name of an existing secret to use for the Keycloak admin API password, instead of setting it in plain text via `apiSecret`.
+    existingSecret: ""
+    secretKeys:
+      # -- Name of the key in the existing secret that contains the Keycloak admin API password.
+      apiSecretKey: "keycloak-api-secret"
     # -- The client ID to use for authenticating to the Keycloak admin API.
     clientId: admin-cli
   livenessProbe:


### PR DESCRIPTION
This PR adds support for using existing Kubernetes Secrets for sensitive ORT Server Helm chart values.

This makes it possible to manage credentials outside of the Helm release, for example through Vault Secrets Operator, External Secrets Operator, or manually created Kubernetes Secrets.

The following components can now reference existing secrets:

* ORT Server database credentials
* RabbitMQ credentials
* Keycloak client credentials
* User secrets encryption credentials
* RabbitMQ administrator credentials
* PostgreSQL credentials
* Grafana administrator credentials

## Configuration

Existing secrets can be configured through the Helm values:

```yaml
database:
  existingSecret: ort-server-db-credentials

transport:
  rabbitmq:
    existingSecret: ort-server-rabbitmq-credentials

core:
  keycloak:
    existingSecret: ort-server-keycloak-credentials

secrets:
  database:
    existingSecret: ort-server-user-secrets-encryption

rabbitmq:
  admin:
    existingSecret: ort-server-rabbitmq-credentials
    userKey: rabbitmq-user
    passwordKey: rabbitmq-password

postgres:
  auth:
    username: ortserver
    existingSecret: ort-server-db-credentials
    secretKeys:
      adminPasswordKey: database-password

loki-stack:
  grafana:
    admin:
      existingSecret: ort-server-grafana
```

## Creating the secrets manually

The required secrets can be created manually with the following commands:

```shell
kubectl create secret generic ort-server-db-credentials \
  --namespace ort-server \
  --from-literal=database-password='<db-password>'
```

```shell
kubectl create secret generic ort-server-rabbitmq-credentials \
  --namespace ort-server \
  --from-literal=rabbitmq-user='<rabbitmq-user>' \
  --from-literal=rabbitmq-password='<rabbitmq-password>'
```

```shell
kubectl create secret generic ort-server-keycloak-credentials \
  --namespace ort-server \
  --from-literal=keycloak-api-secret='<keycloak-api-secret>'
```

```shell
kubectl create secret generic ort-server-user-secrets-encryption \
  --namespace ort-server \
  --from-literal=master-password='<master-password-16-chars-min>' \
  --from-literal=salt='<hex-salt-32-hex-chars-min>'
```

```shell
kubectl create secret generic ort-server-grafana \
  --namespace ort-server \
  --from-literal=admin-password='<grafana-password>' \
  --from-literal=admin-user='<grafana-user>'
```

The secrets must be created in the same namespace as the ORT Server Helm release before installing or upgrading the chart.

